### PR TITLE
Fix `NoMethodError` in puppet_strings_helper.rb

### DIFF
--- a/lib/puppet-languageserver-sidecar/puppet_strings_helper.rb
+++ b/lib/puppet-languageserver-sidecar/puppet_strings_helper.rb
@@ -144,7 +144,7 @@ module PuppetLanguageServerSidecar
               param_name = tag[:name]
               obj.parameters[param_name] = {
                 :doc  => tag[:text],
-                :type => tag[:types].join(', ')
+                :type => tag[:types]&.join(', ')
               }
             end
           end


### PR DESCRIPTION
FYI when ran against our codebase LSP fails with error

```
A, [2022-01-18T12:35:46.485073 #31693]   ANY -- : SidecarQueue Thread: Calling sidecar with --action workspace_aggregate --local-workspace ~/.git/puppet --puppet-version=6.21.1 returned exitcode 1, ~/.git/puppet-editor-services/lib/puppet-languages
erver-sidecar/puppet_strings_helper.rb:147:in `block (3 levels) in populate_classes_from_yard_registry!': undefined method `join' for nil:NilClass (NoMethodError)
        from ~/.git/puppet-editor-services/lib/puppet-languageserver-sidecar/puppet_strings_helper.rb:143:in `each'
        from ~/.git/puppet-editor-services/lib/puppet-languageserver-sidecar/puppet_strings_helper.rb:143:in `block (2 levels) in populate_classes_from_yard_registry!'
        from ~/.git/puppet-editor-services/lib/puppet-languageserver-sidecar/puppet_strings_helper.rb:128:in `each'
        from ~/.git/puppet-editor-services/lib/puppet-languageserver-sidecar/puppet_strings_helper.rb:128:in `block in populate_classes_from_yard_registry!'
        from ~/.git/puppet-editor-services/lib/puppet-languageserver-sidecar/puppet_strings_helper.rb:127:in `each'
        from ~/.git/puppet-editor-services/lib/puppet-languageserver-sidecar/puppet_strings_helper.rb:127:in `populate_classes_from_yard_registry!'
        from ~/.git/puppet-editor-services/lib/puppet-languageserver-sidecar/puppet_strings_helper.rb:102:in `populate_from_yard_registry!'
        from ~/.git/puppet-editor-services/lib/puppet-languageserver-sidecar/puppet_strings_helper.rb:74:in `file_documentation'
        from ~/.git/puppet-editor-services/lib/puppet-languageserver-sidecar/puppet_strings_helper.rb:10:in `file_documentation'
        from ~/.git/puppet-editor-services/lib/puppet-languageserver-sidecar/puppet_helper.rb:93:in `block in retrieve_via_puppet_strings'
        from ~/.git/puppet-editor-services/lib/puppet-languageserver-sidecar/puppet_helper.rb:92:in `each'
        from ~/.git/puppet-editor-services/lib/puppet-languageserver-sidecar/puppet_helper.rb:92:in `retrieve_via_puppet_strings'
        from ~/.git/puppet-editor-services/lib/puppet_languageserver_sidecar.rb:303:in `execute'
        from ~/.git/puppet-editor-services/lib/puppet_languageserver_sidecar.rb:360:in `execute_and_output'
        from ~/.git/puppet-editor-services/puppet-languageserver-sidecar:14:in `<main>'
```

This change fixes this issue.

Let me know how or if I should add specs for this edge-case.
